### PR TITLE
corrects PHP code linter error by invoking parent tearDown() method in test case.

### DIFF
--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -57,6 +57,7 @@ final class filter_test extends advanced_testcase {
     }
 
     protected function tearDown(): void {
+        parent::tearDown();
         unset($this->filter);
     }
 


### PR DESCRIPTION
fixes #16 